### PR TITLE
Fix: Correct PR preview URL and menu link handling

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -102,7 +102,7 @@ jobs:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.number }}
           body: |
-            🚀 PR Preview available at: https://grandtrain.ca/${{ env.preview_subdir }}/
+            🚀 PR Preview available at: https://michellehenault.ca/${{ env.preview_subdir }}/
             (Base content from latest 'main' branch deployment)
             Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           edit-mode: replace


### PR DESCRIPTION
This commit addresses two issues related to PR previews:

1.  **Incorrect Preview URL in PR Comment**: The GitHub Actions workflow (`.github/workflows/preview.yml`) was generating a PR comment with a hardcoded URL pointing to `grandtrain.ca`. This has been corrected to point to `michellehenault.ca`.

2.  **Menu Links in PR Previews**: Menu links in `header.js` (sourced from `menu.json`) were absolute (e.g., `/home/index.html`). In PR previews (e.g., under `/pr-preview/123/`), these links would incorrectly navigate to the live site. The `header.js` has been updated to detect if it's running in a PR preview environment. If so, it dynamically prepends the correct preview base path (e.g., `/pr-preview/123`) to the menu links, ensuring navigation stays within the preview context.