### PR TITLE
feat: Reorganize menu items into submenus

### DIFF
--- a/2013/index.html
+++ b/2013/index.html
@@ -21,7 +21,7 @@
   <meta content="summary_large_image" name="twitter:card" />
   <meta content="2012-2014 sur bois | michellehenault" name="twitter:title" />
   <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image" />
-  <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 
 <body class="mh-body">
@@ -203,7 +203,7 @@
       </div>
     </div>
   </div>
-  <script src="/header.js"></script>
+  <script src="../header.js"></script>
 </body>
 
 </html>

--- a/2015/index.html
+++ b/2015/index.html
@@ -24,7 +24,7 @@
  <meta content="Michelle Henault artiste-peintre, painter" name="twitter:title"/>
  <meta content="Michelle Hénault, artiste peintre, art contemporain, Montréal, oil painting, peinture, huile" name="twitter:description"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">

--- a/2016-2017/index.html
+++ b/2016-2017/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Peinture Paysage Contemporain | Québec | Michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -417,6 +417,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/2019-en-cours/index.html
+++ b/2019-en-cours/index.html
@@ -25,7 +25,7 @@
  <meta content="2019-2020 Série Orange | michellehenault" name="twitter:title"/>
  <meta content="peinture à l'huile, art contemporain, série orange, summertime, le chant de la Loba, paysages à l'huile, " name="twitter:description"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -241,6 +241,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/2020-en-cours/index.html
+++ b/2020-en-cours/index.html
@@ -24,7 +24,7 @@
  <meta content="Peinture Paysage Contemporain | Michellehenault | Montréal" name="twitter:title"/>
  <meta content="www.michellehenault.com, Peinture à l'huile, paysages contemporains, arts visuels" name="twitter:description"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -286,6 +286,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/2022-2023-en-cours/index.html
+++ b/2022-2023-en-cours/index.html
@@ -24,7 +24,7 @@
  <meta content="Michelle Henault, artiste-peintre | Michelle Henault | Montréal, QC, Canada" name="twitter:title"/>
  <meta content="Peinture contemporaine, art visuel, paysages contemporains, peinture à l'huile, art, michellehenault" name="twitter:description"/>
  <meta content="0ee442_919eac1b05834ac19dbe990f161f043f~mv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -219,6 +219,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/about-5/index.html
+++ b/about-5/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="À propos | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -77,6 +77,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/cartes-de-voeux-blank-cards/index.html
+++ b/cartes-de-voeux-blank-cards/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Cartes de voeux/ Blank cards | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -434,6 +434,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/cv/index.html
+++ b/cv/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Info | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -139,6 +139,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/entrevue/index.html
+++ b/entrevue/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="entrevues | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -43,6 +43,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/exposition-2024-photos/index.html
+++ b/exposition-2024-photos/index.html
@@ -24,7 +24,7 @@
  <meta content="Michelle Henault, artiste-peintre | artiste peintre montréal | Montréal, QC, Canada" name="twitter:title"/>
  <meta content="Michelle Henault, artiste-peintre, Montréal, peinture à l'huile, paysages colorés abstraits contemporains, art québécois semi-abstrait, " name="twitter:description"/>
  <meta content="0ee442_13f6133758874a29bb2474b661246219~mv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -47,6 +47,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/exposition/index.html
+++ b/exposition/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Expositions en photos 2023 et 2024 | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -126,6 +126,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/grid/index.html
+++ b/grid/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Les Territoires" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -43,6 +43,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/header.js
+++ b/header.js
@@ -32,7 +32,7 @@ function socialsHTML() {
 // Fonction pour générer le menu de navigation à partir d'un fichier JSON avec sous-menus
 async function navHTML() {
   try {
-    const resp = await fetch('/menu.json');
+    const resp = await fetch('menu.json');
     if (!resp.ok) return '';
     const menu = await resp.json();
     function renderMenu(items) {

--- a/home/index.html
+++ b/home/index.html
@@ -6,7 +6,7 @@
  <meta content="skype_toolbar_parser_compatible" name="skype_toolbar"/>
  <title><!-- ...titre dynamique ou statique... --></title>
  <!-- ...autres meta... -->
- <link rel="stylesheet" href="/styles.css" />
+ <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -345,6 +345,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/laguna-verde/index.html
+++ b/laguna-verde/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Laguna verde 2003 | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -176,6 +176,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/liste/index.html
+++ b/liste/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Boutique | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -611,6 +611,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/menu.json
+++ b/menu.json
@@ -1,6 +1,13 @@
 [
   { "label": "Accueil", "href": "/home/index.html" },
-  { "label": "CV", "href": "/cv/index.html" },
+  { 
+    "label": "Artiste", 
+    "children": [
+      { "label": "CV", "href": "/cv/index.html" },
+      { "label": "Entrevue", "href": "/entrevue/index.html" },
+      { "label": "À propos", "href": "/about-5/index.html" }
+    ] 
+  },
   { "label": "Œuvres", "children": [
     { "label": "2022-2023", "href": "/2022-2023-en-cours/index.html" },
     { "label": "2020", "href": "/2020-en-cours/index.html" },
@@ -12,9 +19,12 @@
     { "label": "Œuvres sur papier", "href": "/oeuvres-sur-papier/index.html" },
     { "label": "Cartes de vœux", "href": "/cartes-de-voeux-blank-cards/index.html" }
   ]},
-  { "label": "Presse", "href": "/presse/index.html" },
-  { "label": "Expositions", "href": "/exposition/index.html" },
-  { "label": "Exposition 2024 (photos)", "href": "/exposition-2024-photos/index.html" },
-  { "label": "Entrevue", "href": "/entrevue/index.html" },
-  { "label": "À propos", "href": "/about-5/index.html" }
+  { 
+    "label": "Visibilité", 
+    "children": [
+      { "label": "Presse", "href": "/presse/index.html" },
+      { "label": "Expositions", "href": "/exposition/index.html" },
+      { "label": "Exposition 2024 (photos)", "href": "/exposition-2024-photos/index.html" }
+    ] 
+  }
 ]

--- a/migrations/index.html
+++ b/migrations/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Série: Les migrations | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -109,7 +109,7 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 
 </html>

--- a/oeuvres-sur-papier/index.html
+++ b/oeuvres-sur-papier/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Oeuvres sur papier | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -148,6 +148,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/presse/index.html
+++ b/presse/index.html
@@ -24,7 +24,7 @@
  <meta content="Revue De Presse | Www.michellehenault.com | Montréal" name="twitter:title"/>
  <meta content="Le chant de la Loba dans Vie des Arts" name="twitter:description"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -182,6 +182,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/propos1/index.html
+++ b/propos1/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="Série «Le chant de la Loba»" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -465,6 +465,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>

--- a/vierge-c1jgd/index.html
+++ b/vierge-c1jgd/index.html
@@ -20,7 +20,7 @@
  <meta content="summary_large_image" name="twitter:card"/>
  <meta content="2014  | michellehenault" name="twitter:title"/>
  <meta content="0ee442_6e3b6a0067044054a393e7d9fde8dc80%7Emv2.jpg" name="twitter:image"/>
- <link rel="stylesheet" href="/styles.css" />
+  <link rel="stylesheet" href="../styles.css" />
 </head>
 <body class="mh-body">
  <div class="mh-container">
@@ -43,6 +43,6 @@
    </div>
   </div>
  </div>
- <script src="/header.js"></script>
+ <script src="../header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Modifies menu.json to group items under new top-level categories "Artiste" and "Visibilité" for better navigation.

- Under "Artiste":
  - CV
  - Entrevue
  - À propos
- Under "Visibilité":
  - Presse
  - Expositions
  - Exposition 2024 (photos)

The header.js script already supports nested menu structures and requires no changes.